### PR TITLE
fix issue when no changelog exist yet

### DIFF
--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -109,7 +109,7 @@ module.exports = function (grunt) {
       });
 
       if (options.dest) {
-        var log = grunt.file.read(options.dest);
+        var log = grunt.file.exists(options.dest)?grunt.file.read(options.dest):'';
         if (options.prepend) {
           log = newLog + log;
         } else {


### PR DESCRIPTION
Check existence of the CHANGELOG file before reading it and create it if necessary
