### PR TITLE
refactor(changelog): Use shelljs for windows friendliness

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.4.0",
-    "grunt-release": "~0.3.3"
+    "grunt-release": "~0.3.3",
+    "shelljs": "~0.1.4"
   }
 }


### PR DESCRIPTION
Can someone on windows (@h-ever) test this pull request and let me know how it works out?  I used shelljs, which is more windows friendly in its approach to running commands.

I don't know how you can make branches of git repositories npm dependencies, so you will have to just clone the repo itself and have the changelog repository changelog itself to test.

```
git clone git://github.com/btford/grunt-conventional-changelog
cd grunt-conventional-changelog
git remote add ajoslin git://github.com/ajoslin/grunt-conventional-changelog
git fetch ajoslin
git checkout -b shelljs ajoslin/shelljs
npm install
grunt changelog
```
