### PR TITLE
fix(task): task fails caused by missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
   ],
   "author": "Brian Ford",
   "license": "BSD",
-  "dependencies": {},
+  "dependencies": {
+    "shelljs": "~0.1.4"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.4.0",
-    "grunt-release": "~0.3.3",
-    "shelljs": "~0.1.4"
+    "grunt-release": "~0.3.3"
   }
 }


### PR DESCRIPTION
latest version, task fails because `shelljs` is a `devDependency` and it should be a `dependency`.
