### PR TITLE
fix(log): correctly generate links to GitHub commits

### DIFF
--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -155,7 +155,7 @@ module.exports = function (grunt) {
             //Generates a commit link if we have a repo, else it generates a plain text commit sha1
             commitLink: function(commit) {
               if (githubRepo) {
-                return '[' + commit + '](' + githubRepo + '/commits/' + commit + ')';
+                return '[' + commit + '](' + githubRepo + '/commit/' + commit + ')';
               } else {
                 return commit;
               }


### PR DESCRIPTION
Link to a commit was broken. This doesn't point anywhere:

```
https://github.com/angular-ui/bootstrap/commits/5f895c13
```

while this one works correctly:

```
https://github.com/angular-ui/bootstrap/commit/5f895c13
```
