### PR TITLE
docs(readme): include git commit message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-conventional-changelog  [![Build Status](https://secure.travis-ci.org/btford/grunt-conventional-changelog.png?branch=master)](http://travis-ci.org/btford/grunt-conventional-changelog)
 
-Generate a changelog from git metadata, using [these](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/) conventions.
+Generate a changelog based on the git commit messages.
 
 ## Example output
 - https://github.com/btford/grunt-conventional-changelog/blob/master/CHANGELOG.md
@@ -33,6 +33,62 @@ grunt.initConfig({
   },
 })
 ```
+
+## Git Commit Guidelines
+
+These rules are adopted from the AngularJS project.
+
+### Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+format that includes a **type**, a **scope** and a **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
+to read on github as well as in various git tools.
+
+### Type
+Is recommended to be one of these (only **feat** and **fix** show up in the changelog:
+
+* **feat**: A new feature
+* **fix**: A bug fix
+* **docs**: Documentation only changes
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc)
+* **refactor**: A code change that neither fixes a bug or adds a feature
+* **test**: Adding missing tests
+* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
+  generation
+
+### Scope
+The scope could be anything specifying place of the commit change. For example `$location`,
+`$browser`, `$compile`, `$rootScope`, `ngHref`, `ngClick`, `ngView`, etc...
+
+### Subject
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes"
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+#### Breaking Changes
+Should be in the footer of the commit with the prefix: `BREAKING CHANGE`
+
+A detailed explanation can be found in this [document][commit-message-format].
 
 ## Options
 
@@ -68,3 +124,5 @@ For instance you can set it to `sublime -w`.
 
 ## License
 BSD
+
+[commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#


### PR DESCRIPTION
Include the git commit message format and a link to the doc
