### PR TITLE
feat(*): optionally set last tag explicitly

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -219,7 +219,7 @@ var getPreviousTag = function() {
 
 
 // PUBLIC API
-exports.generate = function(githubRepo, version) {
+exports.generate = function(githubRepo, version, lastTag) {
   var buffer = {
     data: '',
     write: function(str) {
@@ -228,7 +228,9 @@ exports.generate = function(githubRepo, version) {
   };
   var writer = new Writer(buffer, githubRepo);
 
-  return getPreviousTag().then(function(tag) {
+  var deferredPreviousTag = lastTag ? q.resolve(lastTag) : getPreviousTag(); 
+
+  return deferredPreviousTag.then(function(tag) {
     return readGitLog('^fix|^feat|BREAKING', tag).then(function(commits) {
       writeChangelog(writer, commits, version);
       return buffer.data;

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -43,7 +43,8 @@ module.exports = function (grunt) {
       prepend: true,  // false to append
       github: null,   // default from package.json
       version: null,  // default value from package.json
-      editor: null    // 'sublime -w'
+      editor: null,   // 'sublime -w'
+      lastTag: null   // optionally set the last tag explicitly (useful if auto recognition fails)
     });
 
     var pkg = grunt.config('pkg') || grunt.file.readJSON('package.json');
@@ -52,7 +53,7 @@ module.exports = function (grunt) {
 
 
     // generate changelog
-    changelog.generate(githubRepo, 'v' + newVersion).then(function(data) {
+    changelog.generate(githubRepo, 'v' + newVersion, options.lastTag).then(function(data) {
       var currentLog = grunt.file.exists(options.dest) ? grunt.file.read(options.dest) : '';
       grunt.file.write(options.dest, options.prepend ? data + currentLog : currentLog + data);
 


### PR DESCRIPTION
This commit adds the possibility to set the `lastTag` explicitly rather then letting `grunt-conventional-changelog` figure it out on it's own. This might be useful in certain scenarios. Actually I don't have strong feelings if this should be merged or not. It fulfills my use case and as a good OSS citizen I just share it as it might be useful for others, too.

The following is the description directly taken from the commit message:

For most workflows the task is smart enough
to figure out the last tag on it's own.

However for workflows which create tags
as leafs the auto recognition does not work.

E.g.

```
      0.3.0               0.3.0
   |/                       |
   |  0.2.0  rather than  0.2.0
   |/                       |
   |  0.1.0               0.1.0
   |/                       |
```

Such a workflow makes sense if tags should
include a dist folder wheras the development
branch should not.

With this change one can set the last tag
explicitly with the `lastTag` option.
