### PR TITLE
feat(*): Allow setting the cmd which is used to figure out previous tag

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -9,7 +9,6 @@ var q = require('qq');
 
 
 var GIT_LOG_CMD = 'git log --grep="%s" -E --format=%s %s..HEAD';
-var GIT_TAG_CMD = 'git describe --tags --abbrev=0';
 
 var EMPTY_COMPONENT = '$$';
 var MAX_SUBJECT_LENGTH = 80;
@@ -204,9 +203,9 @@ var writeChangelog = function(writer, commits, version) {
 };
 
 
-var getPreviousTag = function() {
+var getPreviousTag = function(previousTagCmd) {
   var deffered = q.defer();
-  child.exec(GIT_TAG_CMD, function(code, stdout) {
+  child.exec(previousTagCmd, function(code, stdout) {
     if (code) {
       deffered.reject('Cannot get the previous tag.');
     }
@@ -219,7 +218,7 @@ var getPreviousTag = function() {
 
 
 // PUBLIC API
-exports.generate = function(githubRepo, version) {
+exports.generate = function(githubRepo, version, previousTagCmd) {
   var buffer = {
     data: '',
     write: function(str) {
@@ -228,7 +227,7 @@ exports.generate = function(githubRepo, version) {
   };
   var writer = new Writer(buffer, githubRepo);
 
-  return getPreviousTag().then(function(tag) {
+  return getPreviousTag(previousTagCmd).then(function(tag) {
     return readGitLog('^fix|^feat|BREAKING', tag).then(function(commits) {
       writeChangelog(writer, commits, version);
       return buffer.data;

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -40,10 +40,16 @@ module.exports = function (grunt) {
     var done = this.async();
     var options = this.options({
       dest: 'CHANGELOG.md',
-      prepend: true,  // false to append
-      github: null,   // default from package.json
-      version: null,  // default value from package.json
-      editor: null    // 'sublime -w'
+      //false to append
+      prepend: true,
+      //default from package.json
+      github: null,
+      //default value from package.json
+      version: null,
+      // 'sublime -w'
+      editor: null,
+      //default command to figure out last tag. Can be overwritten to match different workflows
+      previousTagCmd: 'git describe --tags --abbrev=0'
     });
 
     var pkg = grunt.config('pkg') || grunt.file.readJSON('package.json');
@@ -52,7 +58,7 @@ module.exports = function (grunt) {
 
 
     // generate changelog
-    changelog.generate(githubRepo, 'v' + newVersion).then(function(data) {
+    changelog.generate(githubRepo, 'v' + newVersion, options.previousTagCmd).then(function(data) {
       var currentLog = grunt.file.exists(options.dest) ? grunt.file.read(options.dest) : '';
       grunt.file.write(options.dest, options.prepend ? data + currentLog : currentLog + data);
 


### PR DESCRIPTION
This is more or less a different take on https://github.com/btford/grunt-conventional-changelog/pull/22.

For most workflows the task is smart enough
to figure out the last tag on it's own.

However for workflows which create tags
as leafs the auto recognition does not work.

E.g.

```
      0.3.0               0.3.0
   |/                       |
   |  0.2.0  rather than  0.2.0
   |/                       |
   |  0.1.0               0.1.0
   |/                       |
```

Such a workflow makes sense if tags should
include a dist folder wheras the development
branch should not.

With this change one can set the cmd which is
used to figure out the previous tag.

For instance to match the sketched scenario
one could set it to:

git tag | sort -n -t. -k1,1 -k2,2 -k3,3 | tail -1
