### PR TITLE
fix(changelog): cannot generate changelog for first tag

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -7,14 +7,22 @@ var child = require('child_process');
 var util = require('util');
 var q = require('qq');
 
-
-var GIT_LOG_CMD = 'git log --grep="%s" -E --format=%s %s..HEAD';
 var GIT_TAG_CMD = 'git describe --tags --abbrev=0';
 
 var EMPTY_COMPONENT = '$$';
 var MAX_SUBJECT_LENGTH = 80;
 
 var PATTERN = /^(\w*)(\(([\w\$\.\-\*]*)\))?\: (.*)$/;
+
+var getGitLogCommand = function(grep, format, from) {
+  var cmd = 'git log --grep="%s" -E --format=%s';
+
+  if (from) {
+    cmd += ' %s..HEAD';
+  }
+
+  return util.format(cmd, grep, format, from);
+}
 
 var warn = function() {
   console.log('WARNING:', util.format.apply(null, arguments));
@@ -92,11 +100,11 @@ var currentDate = function() {
 
 
 var readGitLog = function(grep, from) {
-  log('Reading git log since', from);
+  log('Reading git log since', from ? from : 'root');
 
   var deffered = q.defer();
 
-  child.exec(util.format(GIT_LOG_CMD, grep, '%H%n%s%n%b%n==END==', from), function(code, stdout) {
+  child.exec(getGitLogCommand(grep, '%H%n%s%n%b%n==END==', from), function(code, stdout) {
     var commits = [];
 
     stdout.split('\n==END==\n').forEach(function(rawCommit) {
@@ -228,7 +236,7 @@ exports.generate = function(githubRepo, version) {
   };
   var writer = new Writer(buffer, githubRepo);
 
-  return getPreviousTag().then(function(tag) {
+  return q.when((version === 'v0.0.1' ? '' : getPreviousTag())).then(function(tag) {
     return readGitLog('^fix|^feat|BREAKING', tag).then(function(commits) {
       writeChangelog(writer, commits, version);
       return buffer.data;


### PR DESCRIPTION
Currently if you try to generate a changelog for the first tag `GIT_TAG_CMD` returns an error which bails out of generating the changelog. This patch address this by parsing all commits from the dawn of time until HEAD for your first tag. It also assumes your first tag is `v0.0.1`.
