### PR TITLE
feat(validator): allow 100 characters in commit message

### DIFF
--- a/lib/validate-commit-msg.js
+++ b/lib/validate-commit-msg.js
@@ -13,7 +13,7 @@ var util = require('util');
 var path = require('path');
 
 
-var MAX_LENGTH = 70;
+var MAX_LENGTH = 100;
 var PATTERN = /^(\w*)(\(([\w\$\.\-\*]*)\))?\: (.*)$/;
 var IGNORED = /^(WIP\:|Merge pull request)/;
 var TYPES = {

--- a/test/lib/validate-commit-msg.spec.coffee
+++ b/test/lib/validate-commit-msg.spec.coffee
@@ -28,12 +28,12 @@ describe 'validate-commit-msg', ->
       expect(errors).to.deep.equal []
 
 
-    it 'should validate 70 characters length', ->
+    it 'should validate 100 characters length', ->
       msg = 'fix($compile): something super mega extra giga tera long, maybe even longer... ' +
-            'way over 80 characters'
+            'way over 100 characters'
 
-      expect(m.validateMessage msg ).to.equal INVALID
-      expect(errors).to.deep.equal ['INVALID COMMIT MSG: is longer than 70 characters !']
+      expect(m.validateMessage msg).to.equal INVALID
+      expect(errors).to.deep.equal ['INVALID COMMIT MSG: is longer than 100 characters !']
 
 
     it 'should validate "<type>(<scope>): <subject>" format', ->


### PR DESCRIPTION
just to follow angularjs commit conventions https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
