### PR TITLE
chore(readme): fix typo in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-conventional-changelog  [![Build Status](https://secure.travis-ci.org/btford/grunt-conventional-changelog.png?branch=master)](http://travis-ci.org/btford/grunt-conventional-changelog)
 
-Generate a changelog using [connvetional-changelog](https://github.com/ajoslin/conventional-changelog).
+Generate a changelog using [conventional-changelog](https://github.com/ajoslin/conventional-changelog).
 
 Uses git metadata, based on [these commit conventions](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/).  
 


### PR DESCRIPTION
Fix spelling of https://github.com/ajoslin/conventional-changelog
