### PR TITLE
fix(task): fix that all editors can be started in config

### DIFF
--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -1,5 +1,5 @@
 var changelog = require('conventional-changelog');
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 
 module.exports = function (grunt) {
 
@@ -37,10 +37,14 @@ module.exports = function (grunt) {
       if (options.file) {
         grunt.file.write(options.file, log);
         if (options.editor) {
-          exec(options.editor + ' ' + options.file, function(err) {
-            if (err) {
-              return grunt.fatal('Failed to open editor.', err);
-            }
+          var args = options.editor.split(/\s+/);
+          var binary = args.shift();
+
+          var proc = spawn(binary, args.concat(options.file), { stdio: 'inherit' });
+          proc.on('error', function (err) {
+            grunt.fatal('Failed to open editor.', err);
+          });
+          proc.on('exit', function (code, sig) {
             grunt.log.ok(options.file + ' updated');
             done();
           });


### PR DESCRIPTION
I wasn't able to run a terminal-based editor process in my terminal (OS X 10.8.5, Terminal.app, Node v0.10.28), through the Grunt config `options.editor`, so I changed the way the editor process is forked (`child_process.spawn` instead of `child_process.exec`).

This works now pretty well and I tested the configuration with the following editors:

* `vim` (terminal based)
* `gvim` (window)
* `nano` (terminal based)
* `sublime -w` (window)

I couldn't figure out why `exec` doesn't work for my terminal based editors but I thought, it couldn't hurt to create a PR anyway, in case anyone else was affected.