### PR TITLE
chore(): update conventional-changelog dependency to 0.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "BSD",
   "dependencies": {
-    "conventional-changelog": "0.0.11"
+    "conventional-changelog": "0.0.14"
   },
   "devDependencies": {
     "ava": "0.0.4",


### PR DESCRIPTION
Please update conventional-changelog dependency to 0.0.14 and issue a release because of the bugfixes made in conventional-changelog.