### PR TITLE
docs(README.md): add value for dest to conventionalChangelog settings for Gruntfile.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ grunt.initConfig({
       }
     },
     release: {
-      src: 'CHANGELOG.md'
+      src: 'CHANGELOG.md',
+      dest: 'CHANGELOG.md'
     }
   }
 });


### PR DESCRIPTION
the module won't write the file unless you include a "dest" value in the "release" object in the conventionalChangelog settings in the Gruntfile.js. without it, the file is never created